### PR TITLE
added -Wno-error to opus CFLAGS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -218,7 +218,7 @@ opus:
 		./configure --host=arm-linux-androideabi --disable-shared \
 			--disable-doc \
 			--disable-extra-programs \
-			CFLAGS="$(CFLAGS)" && \
+			CFLAGS="$(CFLAGS) -Wno-error" && \
 		CC="$(CC) --sysroot $(SYSROOT)" \
 		RANLIB=$(RANLIB) AR=$(AR) PATH=$(BIN):$(PATH) \
 		make && \


### PR DESCRIPTION
The flag is needed in order to make opus:

make[3]: Entering directory '/usr/src/baresip-android/opus-1.2.1'
  CC       celt/celt.lo
In file included from celt/celt.c:48:0:
celt/float_cast.h:129:10: error: #warning "Don't have the functions lrint() and lrintf ()." [-Werror=cpp]
         #warning "Don't have the functions lrint() and lrintf ()."
          ^
celt/float_cast.h:130:10: error: #warning "Replacing these functions with a standard C cast." [-Werror=cpp]
         #warning "Replacing these functions with a standard C cast."
          ^
cc1: all warnings being treated as errors
Makefile:2481: recipe for target 'celt/celt.lo' failed
